### PR TITLE
Update readme.md with link to caffeine documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@
 # Caffeine
 
 An alternative stream library
+
+# Documentation
+
+https://hexdocs.pm/caffeine/Caffeine.Stream.html


### PR DESCRIPTION
I just thought it would be great to have a link to the documentation in the readme file so it shows up on the first page of the lib.