### PR TITLE
Add "skip" functionality with tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,4 +12,5 @@ jobs:
       - run: env MIX_ENV=test mix compile
       - run: mix test
       - run: env MIX_ENV=test mix coveralls.circle
+      - run: mix format --check-formatted
       # - run: mix dialyzer

--- a/lib/caffeine.ex
+++ b/lib/caffeine.ex
@@ -276,6 +276,47 @@ defmodule Caffeine do
       t.()
     end
 
+    @doc """
+    Given a stream skips n consecutive elements of it 
+
+    ## Examples
+
+        iex> defmodule Natural do
+        ...>   import Caffeine.Stream, only: [construct: 2]
+        ...> 
+        ...>   def stream do
+        ...>     stream(0)
+        ...>   end
+        ...> 
+        ...>   defp stream(n) do
+        ...>     rest = fn -> stream(increment(n)) end
+        ...>     construct(n, rest)
+        ...>   end
+        ...> 
+        ...>   defp increment(n) do
+        ...>     n + 1
+        ...>   end
+        ...> end
+        iex> Natural.stream()
+        ...> |> Caffeine.Stream.skip(5)
+        ...> |> Caffeine.Stream.take(5)
+        [5, 6, 7, 8, 9]
+
+    """
+    @spec skip(t, integer) :: t
+    def skip(s, 0) do
+      s
+    end
+    def skip(s, n) when is_integer(n) and n > 0 do
+      cond do
+        sentinel?(s) ->
+          sentinel()
+
+        construct?(s) ->
+          skip(tail(s), n - 1)
+      end
+    end
+    
     defp pair(h, r) do
       [h | r]
     end

--- a/lib/caffeine.ex
+++ b/lib/caffeine.ex
@@ -307,6 +307,7 @@ defmodule Caffeine do
     def skip(s, 0) do
       s
     end
+
     def skip(s, n) when is_integer(n) and n > 0 do
       cond do
         sentinel?(s) ->

--- a/test/caffeine/stream_test.exs
+++ b/test/caffeine/stream_test.exs
@@ -119,7 +119,7 @@ defmodule Caffeine.StreamTest do
       t1 = Caffeine.Stream.skip(s, i)
       t2 = Enum.drop(l, i)
       ## then
-      assert length(listify(t1)) == length(t2)
+      assert listify(t1) === t2
     end
   end
 

--- a/test/caffeine/stream_test.exs
+++ b/test/caffeine/stream_test.exs
@@ -99,13 +99,27 @@ defmodule Caffeine.StreamTest do
   property "skip/2 cardinality is less than or equal to input" do
     ## given
     check all l <- list_of(integer()),
-                   i <- integer(),
-                   i >= 0 do
+              i <- integer(),
+              i >= 0 do
       s = CaffeineTest.Ancillary.List.stream(l)
       ## when
       t = Caffeine.Stream.skip(s, i)
       ## then
       assert length(listify(t)) <= length(l)
+    end
+  end
+
+  property "after skip/2 the same elements reside in the rest of the stream" do
+    ## given
+    check all l <- list_of(integer()),
+              i <- integer(),
+              i >= 0 do
+      s = CaffeineTest.Ancillary.List.stream(l)
+      ## when
+      t1 = Caffeine.Stream.skip(s, i)
+      t2 = Enum.drop(l, i)
+      ## then
+      assert length(listify(t1)) == length(t2)
     end
   end
 

--- a/test/caffeine/stream_test.exs
+++ b/test/caffeine/stream_test.exs
@@ -96,6 +96,19 @@ defmodule Caffeine.StreamTest do
     end
   end
 
+  property "skip/2 cardinality is less than or equal to input" do
+    ## given
+    check all l <- list_of(integer()),
+                   i <- integer(),
+                   i >= 0 do
+      s = CaffeineTest.Ancillary.List.stream(l)
+      ## when
+      t = Caffeine.Stream.skip(s, i)
+      ## then
+      assert length(listify(t)) <= length(l)
+    end
+  end
+
   defp identity(x) do
     x
   end

--- a/test/caffeine_test.exs
+++ b/test/caffeine_test.exs
@@ -11,6 +11,7 @@ defmodule CaffeineTest do
              map: 2,
              sentinel: 0,
              sentinel?: 1,
+             skip: 2,
              tail: 1,
              take: 2
            ]


### PR DESCRIPTION
It allows to skip first elements of the stream. This feature can be helpful in orangeade application.